### PR TITLE
New translation for "Bold" in norwegian

### DIFF
--- a/js/langs/nb.js
+++ b/js/langs/nb.js
@@ -9,7 +9,7 @@
 
 $.Editable.LANGS['nb'] = {
   translation: {
-    "Bold": "Halvfet",
+    "Bold": "Fet",
     "Italic": "Kursiv",
     "Underline": "Understreket",
     "Strikethrough": "Gjennomstreket",


### PR DESCRIPTION
Bold is 99% of the time called "fet" and not "halvfet".

In css-terms, "halvfet" is usually a text-weight:300, and "fet" is usually <strong></strong> or text-weight:500
