### PR TITLE
bower.json changes to conform to Bower spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,49 +1,16 @@
 {
     "name": "froala-wysiwyg-editor",
-    "version": "2.0.5",
     "description": "A beautiful jQuery WYSIWYG HTML rich text editor. High performance and modern design make it easy to use for developers and loved by users.",
-    "main": [
-      "css/froala_editor.min.css",
-      "css/froala_style.min.css",
-      "css/plugins/char_counter.min.css",
-      "css/plugins/code_view.min.css",
-      "css/plugins/colors.min.css",
-      "css/plugins/emoticons.min.css",
-      "css/plugins/file.min.css",
-      "css/plugins/fullscreen.min.css",
-      "css/plugins/image_manager.min.css",
-      "css/plugins/image.min.css",
-      "css/plugins/line_breaker.min.css",
-      "css/plugins/table.min.css",
-      "css/plugins/video.min.css",
-      "js/froala_editor.min.js",
-      "js/plugins/align.min.js",
-      "js/plugins/char_counter.min.js",
-      "js/plugins/code_beautifier.min.js",
-      "js/plugins/code_view.min.js",
-      "js/plugins/colors.min.js",
-      "js/plugins/emoticons.min.js",
-      "js/plugins/entities.min.js",
-      "js/plugins/file.min.js",
-      "js/plugins/font_family.min.js",
-      "js/plugins/font_size.min.js",
-      "js/plugins/fullscreen.min.js",
-      "js/plugins/image.min.js",
-      "js/plugins/image_manager.min.js",
-      "js/plugins/inline_style.min.js",
-      "js/plugins/line_breaker.min.js",
-      "js/plugins/link.min.js",
-      "js/plugins/lists.min.js",
-      "js/plugins/paragraph_format.min.js",
-      "js/plugins/paragraph_style.min.js",
-      "js/plugins/quote.min.js",
-      "js/plugins/save.min.js",
-      "js/plugins/table.min.js",
-      "js/plugins/url.min.js",
-      "js/plugins/video.min.js"
-    ],
+    "license": "https://www.froala.com/wysiwyg-editor/terms",
+    "homepage": "https://www.froala.com/wysiwyg-editor",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/froala/wysiwyg-editor.git"
+    },
     "keywords": [
       "froala",
+      "froala-editor",
+      "froala-wysiwyg",
       "html",
       "text",
       "editor",
@@ -55,25 +22,15 @@
       "javascript",
       "jquery"
     ],
-    "ignore": [
-      "examples",
-      "img",
-      "package.json",
-      "bower.json"
+    "moduleType": "globals",
+    "main": [
+      "css/froala_editor.css",
+      "js/froala_editor.min.js"
     ],
-    "licenses": [
-        {
-          "type": "Single Website",
-          "url": "https://www.froala.com/wysiwyg-editor/pricing"
-        },
-        {
-          "type": "Advanced",
-          "url": "https://www.froala.com/wysiwyg-editor/pricing"
-        },
-        {
-          "type": "OEM",
-          "url": "https://www.froala.com/wysiwyg-editor/pricing"
-        }
+    "ignore": [
+      "html",
+      "img",
+      "package.json"
     ],
     "dependencies": {
       "jquery": ">=1.11.0",


### PR DESCRIPTION
Before realizing that this is listed as "froala-wysiwyg-editor" in Bower and not "froala-editor", I was going through the `bower.json` file and comparing it to the [Bower spec](https://github.com/bower/spec/blob/master/json.md). Here are my suggested changes based on how I understand the Bower spec. I'm not sure if you would need to re-register after these changes though... Also, not sure if you'd need to pull this upstream, to a private repo.

* Remove the "version" (depreciated, supposed to rely on GitHub version tags instead)
* Remove the excess "main" listings (supposed to be one per type, although froala is packaged differently so I'm not even sure these are needed)
* Added the "moduleType" key, since froala is technically using globals
* Changed "licenses" to just "license" and pointed it to the actual license agreement Webpage
* Updated the list of ignored content, changed "examples" to "html" and removed "bower.json" since it is required
* Added a couple variations to the list of "keywords"
* Added a link to the "homepage"
* Added the "repository" option, I think it's needed to pull versions
* Re-organized the order of everything, to something that makes a little more sense