### PR TITLE
Add special_characters to bower:main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
     "css/plugins/image.min.css",
     "css/plugins/line_breaker.min.css",
     "css/plugins/quick_insert.min.css",
+    "css/plugins/special_characters.min.css",
     "css/plugins/table.min.css",
     "css/plugins/video.min.css",
     "js/froala_editor.min.js",
@@ -65,6 +66,7 @@
     "js/plugins/quick_insert.min.js",
     "js/plugins/quote.min.js",
     "js/plugins/save.min.js",
+    "js/plugins/special_characters.min.js",
     "js/plugins/table.min.js",
     "js/plugins/url.min.js",
     "js/plugins/video.min.js"


### PR DESCRIPTION
Using bower list -p, the special_characters plugin files are not available.