### PR TITLE
example bug fix, froala menues appears behind

### DIFF
--- a/html/toolbar/external.html
+++ b/html/toolbar/external.html
@@ -37,6 +37,7 @@
         top: 0;
         left: 0;
         right: 0;
+        z-index: 9999;
       }
   </style>
 </head>


### PR DESCRIPTION
example bug fix, froala menues appears behind the html so you can't add for example a link because you can't see the link popup