### PR TITLE
Fix misspelling

### DIFF
--- a/js/languages/sv.js
+++ b/js/languages/sv.js
@@ -163,7 +163,7 @@ $.FE.LANGUAGE['sv'] = {
     "Insert row below": "Infoga rad efter",
     "Delete row": "Ta bort rad",
     "Column": "Kolumn",
-    "Insert column before": "Infoga kollumn f\u00f6re",
+    "Insert column before": "Infoga kolumn f\u00f6re",
     "Insert column after": "Infoga kolumn efter",
     "Delete column": "Ta bort kolumn",
     "Cell": "Cell",


### PR DESCRIPTION
The swedish word for column is "kolumn" with one "l" not two