### PR TITLE
Replace unsupported jQuery syntax in html.get example

### DIFF
--- a/html/api/get_html.html
+++ b/html/api/get_html.html
@@ -45,7 +45,7 @@
 
       <p>You can use at any time in your code the following snippet to get the content inside the Froala WYSIWYG HTML
         Editor</p>
-      <p><code>$('div#selector').froalaEditor('html.get');</code></p>
+      <p><code>editor.html.get(true);</code></p>
     </div>
   </div>
 
@@ -83,7 +83,8 @@
   <script type="text/javascript" src="../../js/plugins/video.min.js"></script>
 
   <script>
-    new FroalaEditor("#edit")
+    editor = new FroalaEditor("#edit");
+    // ... your Froala code
   </script>
 </body>
 


### PR DESCRIPTION
> In version 3 we removed the jQuery dependency and the editor is much easier to initialize.

I used the code example from the [documentation](https://www.froala.com/wysiwyg-editor/docs/methods#html.get) and replaced the jQuery snippet in the html.get example. This should help any newcomer from confusion about the jQuery part.