### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "hello"

--- a/README.md
+++ b/README.md
@@ -227,3 +227,4 @@ If you have questions or need help integrating the editor please [contact us](ht
 ## Licensing
 
 In order to use the Froala Editor you have to purchase one of the following licenses according to your needs. You can find more about that on our website on the [pricing plan page](https://www.froala.com/wysiwyg-editor/pricing).
+[![Run on Repl.it](https://repl.it/badge/github/froala/wysiwyg-editor)](https://repl.it/github/froala/wysiwyg-editor)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).