### PR TITLE
Italian language - Wrong + new translation

### DIFF
--- a/js/languages/it.js
+++ b/js/languages/it.js
@@ -264,7 +264,8 @@
       'Clean': 'Pulisci',
       'Word Paste Detected': "\xC8 stato rilevato un incolla da Word",
       // Character Counter
-      'Characters': 'Personaggi',
+      'Characters': 'Caratteri',
+      'Words': 'Parole',
       // More Buttons
       'More Text': 'Altro testo',
       'More Paragraph': 'Altro paragrafo',


### PR DESCRIPTION
Added the correct translation for
Characters => Caratteri - It was Personaggi which refers to characters of a story.
Words => Parole - This is a new translation