### PR TITLE
Add example to README on accessing `FroalaEditor` via top-namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ import FroalaEditor from 'froala-editor'
 // Load a plugin.
 import 'froala-editor/js/plugins/align.min.js'
 
+// Adds `FroalaEditor` to global namespace (object)
+global.FroalaEditor = FroalaEditor;
+
 // Initialize editor.
 new FroalaEditor('#edit')
 ```


### PR DESCRIPTION
This is a minor but important addition to the README docs to demonstrate that `FroalaEditor` may still resolve as undefined even though `import FroalaEditor from 'froala-editor'` may be defined.

Adding this to the top-level namespace takes care of this.