### PR TITLE
update "fill-available" to "stretch"

### DIFF
--- a/css/froala_editor.pkgd.css
+++ b/css/froala_editor.pkgd.css
@@ -1987,7 +1987,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
   .fr-popup .fr-files-progress-bar-layer > h3 {
     font-size: 16px;
     margin: 10px 0;
@@ -2044,7 +2044,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 .fr-uploading {
   -webkit-opacity: 0.4;
@@ -2108,7 +2108,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 @media screen and (max-width: 399px) {
   .fr-upload-section {

--- a/css/plugins.pkgd.css
+++ b/css/plugins.pkgd.css
@@ -626,7 +626,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
   .fr-popup .fr-files-progress-bar-layer > h3 {
     font-size: 16px;
     margin: 10px 0;
@@ -683,7 +683,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 .fr-uploading {
   -webkit-opacity: 0.4;
@@ -747,7 +747,7 @@ textarea.fr-code {
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 @media screen and (max-width: 399px) {
   .fr-upload-section {

--- a/css/plugins/files_manager.css
+++ b/css/plugins/files_manager.css
@@ -210,7 +210,7 @@
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
   .fr-popup .fr-files-progress-bar-layer > h3 {
     font-size: 16px;
     margin: 10px 0;
@@ -267,7 +267,7 @@
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 .fr-uploading {
   -webkit-opacity: 0.4;
@@ -331,7 +331,7 @@
   /* WebKit-based browsers will ignore this. */
   width: -webkit-fill-available;
   /* Mozilla-based browsers will ignore this. */
-  width: fill-available; }
+  width: stretch; }
 
 @media screen and (max-width: 399px) {
   .fr-upload-section {


### PR DESCRIPTION
The spec has been updated to use the term "stretch" instead of "fill-available".

https://developer.mozilla.org/en-US/docs/Web/CSS/width

I'm not sure if these are compiled files or the source. If they're compiled, then we probably need to disregard this PR, and update the source files instead.