### PR TITLE
Small fix for pt-bt translation

### DIFF
--- a/js/languages/pt_br.js
+++ b/js/languages/pt_br.js
@@ -21,7 +21,7 @@
       'Type something': 'Digite algo',
       // Basic formatting
       'Bold': 'Negrito',
-      'Italic': 'Itálito',
+      'Italic': 'Itálico',
       'Underline': 'Sublinhar',
       'Strikethrough': 'Tachado',
       // Main buttons


### PR DESCRIPTION
`Itálito` is `pt` for `Italy`. The right word for `Italic` is `Itálico`.
See https://translate.google.com/?sl=en&tl=pt&text=Italic&op=translate