### PR TITLE
Introducing Froala Editor V4 Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://api.travis-ci.com/froala-labs/froala-editor-js-2.svg?token=RmiyW7AecDyQ8ja7VMDj&branch=master)](https://travis-ci.com/froala-labs/froala-editor-js-2)
 [![npm](https://img.shields.io/npm/dm/froala-editor.svg)](https://www.npmjs.com/package/froala-editor)
 [![npm](https://img.shields.io/npm/v/froala-editor.svg)](https://www.npmjs.com/package/froala-editor)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Froala%20Editor%20V4%20Guru-006BFF)](https://gurubase.io/g/froala-editor-v4)
 
 Froala WYSIWYG HTML Editor is one of the most powerful JavaScript rich text editors ever.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Froala Editor V4 Guru](https://gurubase.io/g/froala-editor-v4) to Gurubase. Froala Editor V4 Guru uses the data from this repo and data from the [docs](https://www.froala.com/wysiwyg-editor/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Froala Editor V4 Guru", which highlights that Froala Editor V4 now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Froala Editor V4 Guru in Gurubase, just let me know that's totally fine.
